### PR TITLE
Add shared release workflow from reissue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release gem to RubyGems.org
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main
+    with:
+      git_user_email: 'gems@sofwarellc.com'
+      git_user_name: 'SOFware'
+      ruby_version: '3.4'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ SOF::MCM.assign("SOME-ID", "application name")
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+This project is managed with [Reissue](https://github.com/SOFware/reissue). Releases are automated via the [shared release workflow](https://github.com/SOFware/reissue/blob/main/.github/workflows/SHARED_WORKFLOW_README.md). Trigger a release by running the "Release gem to RubyGems.org" workflow from the Actions tab.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ require "reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/sof/mcm/version.rb"
+  task.push_finalize = :branch
 end
 
 require "standard/rake"


### PR DESCRIPTION
## Summary
- Adds shared release workflow from reissue for trusted publishing to RubyGems.org

## Business Justification
Standardizes gem release process across SOFware repos using the shared reissue workflow, enabling automated trusted publishing to RubyGems.org via workflow_dispatch.

## Technical Details
Adds `.github/workflows/release.yml` that calls `SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main`